### PR TITLE
Fix Energy Dashboard spike inflation and monetary state_class warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.6] - 2026-05-03
+
+### Fixed
+- Fixed inflated Energy Dashboard totals (e.g. multi-MWh spikes) caused by transient API parse failures returning `0.0`, which the `total_increasing` state class interpreted as a meter reset followed by a fresh increment. Missing values now yield `None` so sensors briefly become unavailable instead of synthesizing a reset (#3).
+- Fixed `EPBCostSensor` warning: `state_class 'total_increasing' is impossible considering device_class 'monetary'`. Cost sensor now uses `state_class = total`, which is the correct pairing for monetary device classes (#3).
+- Removed broad exception swallowing in `get_usage_data` that returned zeros on any error; failures now propagate so the coordinator marks the update failed and Home Assistant preserves the last known value.
+
 ## [1.0.4] - 2025-03-11
 
 ### Fixed

--- a/custom_components/epb/api.py
+++ b/custom_components/epb/api.py
@@ -11,6 +11,13 @@ from multidict import CIMultiDict
 
 _LOGGER = logging.getLogger(__name__)
 
+_EMPTY_USAGE: Dict[str, Optional[float]] = {
+    "kwh": None,
+    "cost": None,
+    "daily_kwh": None,
+    "daily_cost": None,
+}
+
 
 class PowerAccount(TypedDict):
     """Type for power account data."""
@@ -175,62 +182,44 @@ class EPBApiClient:
 
         Returns:
             A dictionary containing:
-            - kwh: Month-to-date total kWh (for TOTAL_INCREASING sensor)
-            - cost: Month-to-date total cost (for TOTAL_INCREASING sensor)
-            - daily_kwh: Today's kWh usage (for daily tracking)
-            - daily_cost: Today's cost (for daily tracking)
+            - kwh: Month-to-date total kWh, or None if missing
+            - cost: Month-to-date total cost, or None if missing
+            - daily_kwh: Today's kWh usage, or None if missing
+            - daily_cost: Today's cost, or None if missing
+
+        None is used (rather than 0.0) so sensors report ``unavailable``
+        on transient parse failures instead of a synthetic zero, which
+        a TOTAL_INCREASING sensor would treat as a meter reset.
         """
-        result: Dict[str, Any] = {
-            "kwh": 0.0,
-            "cost": 0.0,
-            "daily_kwh": 0.0,
-            "daily_cost": 0.0,
-        }
+        result: Dict[str, Any] = dict(_EMPTY_USAGE)
 
         try:
-            # Get month-to-date totals (primary data for Energy Dashboard)
-            if "interval_a_totals" in data:
-                totals = data["interval_a_totals"]
-                result["kwh"] = float(totals.get("pos_kwh", 0))
-                result["cost"] = float(totals.get("pos_wh_est_cost", 0))
-                _LOGGER.debug(
-                    "Month-to-date totals: %s kWh, $%s",
-                    result["kwh"],
-                    result["cost"],
-                )
+            totals = data.get("interval_a_totals") or {}
+            if "pos_kwh" in totals:
+                result["kwh"] = float(totals["pos_kwh"])
+            if "pos_wh_est_cost" in totals:
+                result["cost"] = float(totals["pos_wh_est_cost"])
 
-            # Get today's daily usage from the data array
-            if "data" in data and data["data"]:
-                daily_data = data["data"]
-                # Find the last entry that has actual data (today or most recent)
-                for entry in reversed(daily_data):
-                    if "a" in entry and "values" in entry["a"]:
-                        daily_values = entry["a"]["values"]
-                        result["daily_kwh"] = float(daily_values.get("pos_kwh", 0))
-                        result["daily_cost"] = float(
-                            daily_values.get("pos_wh_est_cost", 0)
-                        )
-                        _LOGGER.debug(
-                            "Daily usage: %s kWh, $%s",
-                            result["daily_kwh"],
-                            result["daily_cost"],
-                        )
-                        break
+            for entry in reversed(data.get("data") or []):
+                values = entry.get("a", {}).get("values")
+                if not values:
+                    continue
+                if "pos_kwh" in values:
+                    result["daily_kwh"] = float(values["pos_kwh"])
+                if "pos_wh_est_cost" in values:
+                    result["daily_cost"] = float(values["pos_wh_est_cost"])
+                break
 
-            # Fallback: if no totals but we have daily data, use daily as totals
-            if result["kwh"] == 0.0 and result["daily_kwh"] > 0:
-                result["kwh"] = result["daily_kwh"]
-                result["cost"] = result["daily_cost"]
-                _LOGGER.warning("No totals found, using daily values as fallback")
+            _LOGGER.debug("Parsed usage: %s", result)
 
-            if result["kwh"] == 0.0 and result["daily_kwh"] == 0.0:
-                _LOGGER.warning("No valid data found in response")
+            if result["kwh"] is None and result["daily_kwh"] is None:
+                _LOGGER.warning("No valid data found in response: %s", data)
 
             return result
 
         except (KeyError, IndexError, TypeError, ValueError) as err:
             _LOGGER.error("Error parsing usage data: %s. Data: %s", err, data)
-            return result
+            return dict(_EMPTY_USAGE)
 
     async def get_usage_data(
         self, account_id: str, gis_id: Optional[int]
@@ -290,10 +279,3 @@ class EPBApiClient:
 
         except ClientError as err:
             raise EPBApiError(f"Connection error fetching usage data: {err}") from err
-        except Exception as err:
-            _LOGGER.error(
-                "Error getting usage data for account %s: %s",
-                account_id,
-                err,
-            )
-            return {"kwh": 0.0, "cost": 0.0, "daily_kwh": 0.0, "daily_cost": 0.0}

--- a/custom_components/epb/manifest.json
+++ b/custom_components/epb/manifest.json
@@ -10,5 +10,5 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/asachs01/ha-epb/issues",
     "requirements": [],
-    "version": "1.0.5"
+    "version": "1.0.6"
 }

--- a/custom_components/epb/sensor.py
+++ b/custom_components/epb/sensor.py
@@ -99,7 +99,7 @@ class EPBCostSensor(EPBSensorBase):
     """Sensor for EPB month-to-date energy cost."""
 
     _attr_device_class = SensorDeviceClass.MONETARY
-    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_state_class = SensorStateClass.TOTAL
     _attr_native_unit_of_measurement = "$"
 
     def __init__(

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="ha-epb",
-    version="1.0.5",
+    version="1.0.6",
     description="Home Assistant integration for EPB (Electric Power Board)",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -101,6 +101,42 @@ async def test_get_usage_data_success(mock_session: AsyncMock) -> None:
     mock_session.post.assert_called_once()
 
 
+async def test_get_usage_data_missing_totals_returns_none(
+    mock_session: AsyncMock,
+) -> None:
+    """Missing totals must yield None, not 0.0, to avoid phantom resets."""
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json.return_value = {"data": []}
+
+    mock_session.post.return_value.__aenter__.return_value = mock_response
+
+    client = EPBApiClient("test@example.com", "password", mock_session)
+    client._token = "test-token"
+
+    result = await client.get_usage_data("123", "456")
+
+    assert result["kwh"] is None
+    assert result["cost"] is None
+    assert result["daily_kwh"] is None
+    assert result["daily_cost"] is None
+
+
+async def test_get_usage_data_http_error_raises(mock_session: AsyncMock) -> None:
+    """Non-200 responses must raise so the coordinator can mark UpdateFailed."""
+    mock_response = AsyncMock()
+    mock_response.status = 500
+    mock_response.text.return_value = "boom"
+
+    mock_session.post.return_value.__aenter__.return_value = mock_response
+
+    client = EPBApiClient("test@example.com", "password", mock_session)
+    client._token = "test-token"
+
+    with pytest.raises(EPBApiError):
+        await client.get_usage_data("123", "456")
+
+
 async def test_token_refresh_on_expired(mock_session: AsyncMock) -> None:
     """Test token refresh when expired."""
     # Skip this test for now due to errors


### PR DESCRIPTION
## Summary
- Fixes #3 — both the multi-MWh dashboard inflation and the `state_class 'total_increasing' is impossible considering device_class 'monetary'` log warning.
- `EPBCostSensor` now uses `state_class = total` (the correct pairing for a monetary device class).
- API client returns `None` for missing values instead of `0.0`. Previously, a transient parse failure produced a synthetic `0.0`, which `total_increasing` interpreted as a meter reset followed by a fresh increment of the next reading — compounding into the 2.87 MWh/$389 totals reported.
- Removed the broad `except Exception` in `get_usage_data` that swallowed errors and returned zero dicts. Failures now propagate as `EPBApiError`, so the coordinator marks `UpdateFailed` and HA preserves the last known value.
- Bumped to `1.0.6`, updated `CHANGELOG.md`.

## Test plan
- [x] `pytest tests/` — 12 passed, 6 pre-existing skips.
- [ ] Install on user's HA, confirm `EPBCostSensor` warning is gone.
- [ ] Confirm Energy Dashboard daily bars match real daily kWh deltas (sanity-check the next 2-3 days against the EPB web portal).